### PR TITLE
[fix] Prevent Chapyter config assignment from failing when there is a white space 

### DIFF
--- a/chapyter/magic.py
+++ b/chapyter/magic.py
@@ -353,6 +353,10 @@ Will add more soon.
         - %chapyter <parameter_name>=<value>
           set the value of the parameter
         """
+
+        # This code is inspired by the %config magic command in IPython
+        # See the code here: https://github.com/ipython/ipython/blob/6b17e43544316d691376e35e677032a4b00d6eeb/IPython/core/magics/config.py#L36
+
         # remove text after comments
         line = line.strip().split("#")[0].strip()
 

--- a/chapyter/magic.py
+++ b/chapyter/magic.py
@@ -366,7 +366,7 @@ Will add more soon.
             return
         elif line in all_class_configs.keys():
             return getattr(self, line)
-        elif "=" in line and line.split("=")[0] in all_class_configs.keys():
+        elif "=" in line and line.split("=")[0].strip() in all_class_configs.keys():
             cfg = Config()
             exec(f"cfg.{self.__class__.__name__}." + line, self.shell.user_ns, locals())
             self.update_config(cfg)

--- a/tests/test_chapyter.py
+++ b/tests/test_chapyter.py
@@ -1,0 +1,40 @@
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+
+from chapyter.magic import Chapyter
+
+
+def test_chapyter_config():
+    shell = TerminalInteractiveShell()
+    shell.run_line_magic("load_ext", "chapyter")
+
+    # Test whether it can display the help message
+    result = shell.run_line_magic("chapyter", "")
+
+    # Test whether it can display the correct default values
+    traits = Chapyter.class_own_traits()
+    for key, value in traits.items():
+        result = shell.run_line_magic("chapyter", key)
+
+        # Skip for cases where the default value is None or empty string
+        # TODO: check why there is such inconsistency
+        if result is None and value.default_value == "":
+            continue
+
+        assert result == value.default_value
+
+    # Test whether it can be used to properly set the values
+    for key, value in traits.items():
+        if isinstance(value, str):
+            shell.run_line_magic("chapyter", f"{key}='test'")
+            result = shell.run_line_magic("chapyter", key)
+            assert result == "test"
+        # Skip for other types for now
+
+    # Test whether it can be used to properly set the values
+    # For cases where there is a space between the value and the equal sign
+    # See https://github.com/chapyter/chapyter/issues/36
+    for key, value in traits.items():
+        if isinstance(value, str):
+            shell.run_line_magic("chapyter", f"{key} = 'text'")
+            result = shell.run_line_magic("chapyter", key)
+            assert result == "text"


### PR DESCRIPTION
See #36 